### PR TITLE
fix: navigation z-index to 10

### DIFF
--- a/src/scss/components/_navigation.scss
+++ b/src/scss/components/_navigation.scss
@@ -5,6 +5,7 @@
 .navigation {
   @include position-fixed;
   background-color: $c-pure-white;
+  z-index: $z-index-10;
 
   &__container {
     @include flex-row-space-between;


### PR DESCRIPTION
## ✍️ Description

Fix navigation z-index to 10 so it sits on top of the content with a white background.

Let me know if you have any questions and here is a [link](https://sparkbox.invisionapp.com/share/WMTRI59Y9FJ#/382582422_AME_Homepage_Desktop) to my design. :)
